### PR TITLE
added new yaml variables for the omnibar link

### DIFF
--- a/src/partials/partial-omnibar.hbs
+++ b/src/partials/partial-omnibar.hbs
@@ -15,7 +15,9 @@
       // Look into making this mirror the Angular Directive
       $('.productmenucontainer').append($('.navbar-nav').clone().toggleClass('nav-items bb-omnibar-productmenu'));
 
-      $('.servicename').wrapInner('<a id="omnibar-link" href="{{ stache.config.base }}"></a>');
+    {{# if stache.config.omnibar_link_enabled }}
+      $('.servicename').wrapInner('<a id="omnibar-link" href="{{ stache.config.omnibar_link }}"></a>');
+    {{/ if }}
 
     }
   });

--- a/stache.yml
+++ b/stache.yml
@@ -33,6 +33,8 @@ livereload: 4100
 omnibar_title: Developer
 omnibar_help: 'false'
 omnibar_search: 'false'
+omnibar_link: <%= stache.config.base %>
+omnibar_link_enabled: true
 
 # =============================================
 # STACHE - LAYOUTS


### PR DESCRIPTION
Added two new yaml variables: omnibar_link and omnibar_link_enabled. The first one will let you change the omnibar link to whatever you wish. The second will let you turn the omnibar link on or off. The default will be set to the home page and true. 
