### PR TITLE
Using a different method to load npm tasks

### DIFF
--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -1248,23 +1248,18 @@ module.exports = function (grunt) {
          * Load Dependencies.
          */
         cwd = process.cwd();
-        inRootDirectory = ((cwd + '/').indexOf(grunt.config.get('stache.dir')) === -1);
-        isNpm2 = grunt.file.exists(grunt.config.get('stache.dir') + 'node_modules');
-
-        // Change the base to reflect Stache's node_modules folder.
-        if (inRootDirectory && isNpm2) {
-            grunt.file.setBase(grunt.config.get('stache.dir'));
-        }
-
-        // Load the modules.
         modules.forEach(function (module) {
-            grunt.loadNpmTasks(module);
+            switch (grunt.file.isDir(cwd + '/node_modules/' + module)) {
+                case false:
+                    grunt.file.setBase(grunt.config.get('stache.dir'));
+                    grunt.loadNpmTasks(module);
+                    grunt.file.setBase(cwd);
+                break;
+                case true:
+                    grunt.loadNpmTasks(module);
+                break;
+            }
         });
-
-        // Revert base to what it was.
-        if (inRootDirectory && isNpm2) {
-            grunt.file.setBase(cwd);
-        }
 
         /**
          * Private Tasks


### PR DESCRIPTION
https://github.com/blackbaud/stache/commit/0233dd5b8d887499dd17ab2fa825494277b7768e added support for standalone Stache instances on NPM 2 and NPM 3, but failed when being included in another NPM package.  This method works for all 4 scenarios, nested and standalone, NPM 2 and NPM 3.
