### PR TITLE
Added correct sidebar sorting

### DIFF
--- a/src/layouts/layout-blog-post.hbs
+++ b/src/layouts/layout-blog-post.hbs
@@ -1,6 +1,8 @@
 ---
 layout: layout-sidebar
 limit: <%= stache.config.blog_recent_limit %>
+sortKey: 'uri'
+sortDesc: true
 ---
 
 {{ include 'partial-blog-header' this isSingle=true }}


### PR DESCRIPTION
As with previous commit, adding correct sidebar sorting to the `layout-blog-post`
