### PR TITLE
Adjusting for breadcrumbs and/or Omnibar

### DIFF
--- a/src/js/stache-jquery.js
+++ b/src/js/stache-jquery.js
@@ -20,7 +20,7 @@
         // Affix
         sidebarNav.affix({
             offset: {
-                top: body.css('padding-top').replace('px', ''),
+                top: $('.layout-sidebar-row').offset().top - 30,
                 bottom: $('.affix-stop').outerHeight()
             }
         });
@@ -30,9 +30,10 @@
             sidebarNav.css('width', sidebar.width() + 'px');
         }).trigger('resize');
 
-        // Scrollspy
+        // Scrollspy - Offset accommodates extra CSS, which accommodates Omnibar
         body.scrollspy({
-            target: '.headings'
+            target: '.headings',
+            offset: 10
         });
 
     }

--- a/src/layouts/layout-sidebar.hbs
+++ b/src/layouts/layout-sidebar.hbs
@@ -3,7 +3,7 @@ layout: layout-container
 showHeadings: true
 ---
 
-<div class="row">
+<div class="row layout-sidebar-row">
   <div class="col-sm-3">
     <div class="sidebar">
       {{# minify collapseWhitespace=true removeEmptyElements=true }}

--- a/src/sass/_generic.scss
+++ b/src/sass/_generic.scss
@@ -32,6 +32,15 @@ p {
   line-height: 1.6em;
 }
 
+/* When scrolling to anchor, accomodate the Omnibar */
+h2[id]:before {
+  display: block;
+  content: " ";
+  margin-top: -35px;
+  height: 35px;
+  visibility: hidden;
+}
+
 .text-primary {
   color: $bb-brand-alternate;
 }

--- a/src/sass/_sidebar.scss
+++ b/src/sass/_sidebar.scss
@@ -7,7 +7,7 @@
   .sidebar {
     font-size: $font-size-base;
     line-height: $line-height-base;
-    margin-top: 20px;
+    margin-top: 18px;
   }
 
   .nav-sidebar.affix {


### PR DESCRIPTION
Fixes #30
- Scrolling to an anchor from the sidebar or via the URL causes the h2 (configurable) in question to be under the Omnibar.  This fixes that via CSS only.
- The affix behavior of the sidebar did not accommodate a page with breadcrumbs.  This allows for either scenario.
