### PR TITLE
[BUGFIX] Sidebar Navigation Sorting By Key

### DIFF
--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -360,6 +360,8 @@ module.exports.register = function (Handlebars, options, params) {
                 this[key] = utils.mergeOption(config[key], this[key]);
             }
 
+
+
             return options.fn(this);
         },
 
@@ -561,8 +563,12 @@ module.exports.register = function (Handlebars, options, params) {
                         // Add any hash values to the context.
                         if (options.hash) {
                             for (h in options.hash) {
+
+                                // These fields should NOT be propagated into child scopes:
                                 switch (h) {
                                     case "nav_links":
+                                    case "sortKey":
+                                    case "sortDesc":
                                     break;
                                     default:
                                     context[i][h] = options.hash[h];

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -563,16 +563,18 @@ module.exports.register = function (Handlebars, options, params) {
                         // Add any hash values to the context.
                         if (options.hash) {
                             for (h in options.hash) {
+                                if (options.hash.hasOwnProperty(h)) {
 
-                                // These fields should NOT be propagated into child scopes:
-                                switch (h) {
-                                    case "nav_links":
-                                    case "sortKey":
-                                    case "sortDesc":
-                                    break;
-                                    default:
-                                    context[i][h] = options.hash[h];
-                                    break;
+                                    // These fields should NOT be propagated into child scopes:
+                                    switch (h) {
+                                        case "nav_links":
+                                        case "sortKey":
+                                        case "sortDesc":
+                                        break;
+                                        default:
+                                            context[i][h] = options.hash[h];
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -542,9 +542,8 @@ module.exports.register = function (Handlebars, options, params) {
                     });
                 }
 
-
-
                 j = context.length;
+
                 for (i; i < j; i++) {
 
                     // Don't go past our limit
@@ -562,8 +561,12 @@ module.exports.register = function (Handlebars, options, params) {
                         // Add any hash values to the context.
                         if (options.hash) {
                             for (h in options.hash) {
-                                if (h !== "nav_links" && options.hash.hasOwnProperty(h)) {
+                                switch (h) {
+                                    case "nav_links":
+                                    break;
+                                    default:
                                     context[i][h] = options.hash[h];
+                                    break;
                                 }
                             }
                         }

--- a/src/layouts/layout-sidebar.hbs
+++ b/src/layouts/layout-sidebar.hbs
@@ -1,8 +1,6 @@
 ---
 layout: layout-container
 showHeadings: true
-sortKey: ""
-sortDesc: false
 ---
 
 <div class="row">
@@ -14,18 +12,19 @@ sortDesc: false
         {{/ if }}
 
         {{# withNavLinks }}
+
           {{# isActiveNav dest=../page.dest }}
             <ul class="nav nav-stacked nav-sidebar">
 
               {{# if showTitle }}
-                  <li class="title {{# if draft }}draft{{/ if }}">
-                    <a href="{{ uri }}">
-                      {{ name }}
-                    </a>
-                  </li>
+                <li class="title {{# if draft }}draft{{/ if }}">
+                  <a href="{{ uri }}">
+                    {{ name }}
+                  </a>
+                </li>
               {{/ if}}
 
-              {{ include 'partial-sidebar' this sidebarCurrentDepth="0" sidebarParentDepth=../../sidebarParentDepth dest=../../page.dest showHeadings=../../../showHeadings page=../../../pagination.index.page sortKey=this.sortKey sortDesc=this.sortDesc }}
+              {{ include 'partial-sidebar' this sidebarCurrentDepth="0" sidebarParentDepth=../../sidebarParentDepth dest=../../page.dest showHeadings=../../../showHeadings page=../../../pagination.index.page }}
 
               <li class="visible-on-affix">
                 <a href="#top" class="smooth-scroll">

--- a/src/layouts/layout-sidebar.hbs
+++ b/src/layouts/layout-sidebar.hbs
@@ -1,6 +1,8 @@
 ---
 layout: layout-container
 showHeadings: true
+sortKey: ""
+sortDesc: false
 ---
 
 <div class="row">
@@ -23,7 +25,7 @@ showHeadings: true
                   </li>
               {{/ if}}
 
-              {{ include 'partial-sidebar' this sidebarCurrentDepth="0" sidebarParentDepth=../../sidebarParentDepth dest=../../page.dest showHeadings=../../../showHeadings page=../../../pagination.index.page sortKey=../../../sortKey sortDesc=../../../sortDesc }}
+              {{ include 'partial-sidebar' this sidebarCurrentDepth="0" sidebarParentDepth=../../sidebarParentDepth dest=../../page.dest showHeadings=../../../showHeadings page=../../../pagination.index.page sortKey=this.sortKey sortDesc=this.sortDesc }}
 
               <li class="visible-on-affix">
                 <a href="#top" class="smooth-scroll">

--- a/src/partials/partial-sidebar.hbs
+++ b/src/partials/partial-sidebar.hbs
@@ -1,5 +1,4 @@
 {{# if nav_links }}
-
   {{# eachWithMod nav_links limit=limit sortKey=sortKey sortDesc=sortDesc }}
     {{# isActiveNav dest=../../dest }}
 

--- a/stache.yml
+++ b/stache.yml
@@ -109,6 +109,8 @@ video_description_top: false
 watchNewer: true
 modules:
   - stache
+sortKey: ""
+sortDesc: false
 
 # =============================================
 # STACHE - ANALYTICS

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -489,6 +489,11 @@ module.exports = function (grunt) {
                     'sortKey',
                     'sortDesc'
                 ];
+
+                if (frontMatter.layout === undefined) {
+                    frontMatter.layout = grunt.config.get('assemble.options.layout');
+                }
+
                 layoutFrontMatter = layoutsFrontMatter[frontMatter.layout];
 
                 fields.forEach(function (field) {

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -78,6 +78,11 @@ module.exports = function (grunt) {
                         '**/*.hbs',
                         '**/*.html'
                     ]
+                },
+                layouts: {
+                    expand: true,
+                    cwd: 'node_modules/blackbaud-stache/src/layouts/',
+                    src: ['**/*.hbs']
                 }
             },
 
@@ -132,12 +137,16 @@ module.exports = function (grunt) {
                 layoutext: '.hbs',
                 layout: 'layout-container',
                 stache: '<%= stache %>',
+                plugins: [],
 
                 // https://github.com/assemble/assemble/pull/468#issuecomment-38730532
                 initializeEngine: function (engine, options)  {
                     var search = "{{\\s*body\\s*}}";
                     engine.bodyRegex = new RegExp(search, 'ig');
-                    engine.init(options, { grunt: grunt, assemble: assemble });
+                    engine.init(options, {
+                        grunt: grunt,
+                        assemble: assemble
+                    });
                 },
 
                 getBypassContext: function () {
@@ -442,6 +451,7 @@ module.exports = function (grunt) {
             var contentDir,
                 files,
                 filesConfig,
+                layoutsFrontMatter,
                 nav_exclude,
                 navKey,
                 page,
@@ -452,6 +462,45 @@ module.exports = function (grunt) {
                 sorted;
 
             slog("Building navigation links...Please wait.");
+
+            function getLayoutsFrontMatter() {
+                var files,
+                    frontMatter,
+                    layoutsConfig,
+                    stacheYaml;
+
+                stacheYaml = utils.getMergedStacheYaml();
+                layoutsConfig = grunt.config.get('stache.globPatterns.layouts');
+                files = grunt.file.expand(layoutsConfig, layoutsConfig.src);
+                frontMatter = {};
+
+                files.forEach(function (layout) {
+                    frontMatter[layout.replace('.hbs', '')] = merge.recursive(true, stacheYaml, yfm.extractJSON('node_modules/blackbaud-stache/src/layouts/' + layout));
+                });
+
+                return frontMatter;
+            }
+
+            function setPageFrontMatterFields(frontMatter) {
+                var fields,
+                    layoutFrontMatter;
+
+                fields = [
+                    'sortKey',
+                    'sortDesc'
+                ];
+                layoutFrontMatter = layoutsFrontMatter[frontMatter.layout];
+
+                fields.forEach(function (field) {
+                    if (frontMatter[field]) {
+                        if (layoutFrontMatter && layoutFrontMatter[field]) {
+                            frontMatter[field] = merge(true, layoutFrontMatter[field], frontMatter[field]);
+                        }
+                    } else {
+                        frontMatter[field] = layoutFrontMatter[field];
+                    }
+                });
+            }
 
             // User has manually specific nav_links in stache.yml. Let's use that.
             if (grunt.config('stache.config.nav_type') !== 'directory') {
@@ -471,6 +520,7 @@ module.exports = function (grunt) {
             filesConfig = grunt.config.get('stache.globPatterns.content');
             files = grunt.file.expand(filesConfig, filesConfig.src);
             nav_exclude = grunt.config.get('stache.config.nav_exclude') || [];
+            layoutsFrontMatter = getLayoutsFrontMatter();
 
             // Reset bypassContext
             grunt.config.set(root + navKey, []);
@@ -478,15 +528,22 @@ module.exports = function (grunt) {
             // Add the pages from the content directory
             if (files) {
                 files.forEach(function (file) {
-                    var fm = yfm.extractJSON(contentDir + file);
-                    if (typeof fm.published === 'undefined' || fm.published !== false) {
+                    var frontMatter;
+
+                    frontMatter = yfm.extractJSON(contentDir + file);
+
+                    if (typeof frontMatter.published === 'undefined' || frontMatter.published !== false) {
+
                         slog.verbose("Adding nav_link from content/ " + file);
+
+                        setPageFrontMatterFields(frontMatter);
+
                         sorted.push({
                             abspath: file,
                             rootdir: file.substr(0, file.indexOf('/')),
                             subdir: file.substr(0, file.lastIndexOf('/')),
                             filename: file.substr(file.lastIndexOf('/') + 1),
-                            frontmatter: fm,
+                            frontmatter: frontMatter,
                             type: 'local'
                         });
                     }
@@ -1117,7 +1174,7 @@ module.exports = function (grunt) {
         /**
          * Merges local and global Stache YAML files into stache.config.
          */
-        extendStacheConfig: function () {
+        getMergedStacheYaml: function () {
             var configFileString,
                 localConfig,
                 stache,
@@ -1171,8 +1228,6 @@ module.exports = function (grunt) {
 
             // Merge global and local Stache config objects.
             stache.config = merge.recursive(true, stacheConfig, localConfig);
-            utils.checkDeprecatedYAML(stache.config);
-            grunt.config.set('stache.config', stache.config);
             return stache.config;
         },
 
@@ -1183,6 +1238,14 @@ module.exports = function (grunt) {
          */
         isArray: function (arr) {
             return (arr.pop && arr.push);
+        },
+
+        /**
+         * Sets global Stache config.
+         */
+        setStacheConfig: function (config) {
+            utils.checkDeprecatedYAML(config);
+            grunt.config.set('stache.config', config);
         },
 
         /**
@@ -1330,7 +1393,7 @@ module.exports = function (grunt) {
         grunt.config.merge(defaults);
 
         // Merge local and global stache.yml config.
-        utils.extendStacheConfig();
+        utils.setStacheConfig(utils.getMergedStacheYaml());
 
         cwd = process.cwd();
         stacheModulesDirectory = grunt.config.get('stache.dir') + 'node_modules/';

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -490,6 +490,10 @@ module.exports = function (grunt) {
                     'sortDesc'
                 ];
 
+                if (layoutsFrontMatter[0] === undefined) {
+                    return false;
+                }
+
                 if (frontMatter.layout === undefined) {
                     frontMatter.layout = grunt.config.get('assemble.options.layout');
                 }

--- a/tests/helpers.spec.js
+++ b/tests/helpers.spec.js
@@ -33,7 +33,9 @@
     stache.tasks.createAutoNav();
 
     // Run the register method to retrieve our custom helpers.
-    helpers.register(Handlebars, {}, { assemble: grunt.config.get('assemble') });
+    helpers.register(Handlebars, {}, {
+        assemble: grunt.config.get('assemble')
+    });
 
     /**
      * Returns the first link in 'nav_links' that is not the home page.

--- a/tests/stache.spec.js
+++ b/tests/stache.spec.js
@@ -75,23 +75,23 @@
      * Stache Utilities
      */
     describe('Stache Utilities', function () {
-        describe('extendStacheConfig()', function () {
+        describe('getMergedStacheYaml()', function () {
             it('should return an object', function () {
-                var config = stache.utils.extendStacheConfig();
+                var config = stache.utils.getMergedStacheYaml();
                 expect(config).toEqual(jasmine.any(Object));
             });
             it('should merge global stache.yml with local stache.yml', function () {
                 var config;
                 grunt.config.set('stache.pathConfig', 'tests/fixtures/stache.yml');
                 grunt.config.set('stache.dir', '../');
-                config = stache.utils.extendStacheConfig();
+                config = stache.utils.getMergedStacheYaml();
                 expect(config.base).toBe('different/base');
             });
             it('should merge global stache.yml with any custom .yml files, if provided', function () {
                 var config;
                 grunt.config.set('stache.dir', '../');
                 grunt.option('config', 'tests/fixtures/custom1.yml,tests/fixtures/custom2.yml');
-                config = stache.utils.extendStacheConfig();
+                config = stache.utils.getMergedStacheYaml();
                 expect(config.base).toBe('yet/another/base');
                 expect(config.foo).toBe('bar');
             });


### PR DESCRIPTION
The biggest changes occur in **tasks/stache.js**. I had to add the `sortKey` and `sortDesc` properties directly to the `nav_links` array. What's more, I had to make sure that these properties were reflective of the chain of inheritance (from **stache.yml** to the layout's Front Matter, to the page's Front Matter).

I also had to add a check inside `eachWithMod` to make sure certain properties weren't being added to child scopes. This probably isn't the best solution, so we may want to discuss future-proofing this approach for a future release.

(I haven't tested on a Sandcastle implementation; doing that now.)
