### PR TITLE
Adding Pull Approve config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,12 @@
+# Many of the defaults are fine for our use.
+# Members are case-sensitive
+# http://docs.pullapprove.com/yaml/
+approve_by_comment: true
+reset_on_reopened: true
+approve_regex: '^Approve'
+reject_regex: '^Needs Change'
+reviewers:
+    required: 1
+    members:
+      - Blackbaud-BobbyEarl
+      - Blackbaud-SteveBrush


### PR DESCRIPTION
First of many efforts to mirror the SKY UX workflow.  The Pull Approve service allows pull requests to be "approved" before they're merged.
