### PR TITLE
Removed sorting from Handlebars and templates.

### DIFF
--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -352,15 +352,16 @@ module.exports.register = function (Handlebars, options, params) {
                 keysLength;
 
             config = stache.config;
-            keys = ['showBreadcrumbs', 'blogReadMoreLabel'];
+            keys = [
+                'showBreadcrumbs',
+                'blogReadMoreLabel'
+            ];
             keysLength = keys.length;
 
             for (i = 0; i < keysLength; ++i) {
                 key = keys[i];
                 this[key] = utils.mergeOption(config[key], this[key]);
             }
-
-
 
             return options.fn(this);
         },
@@ -524,25 +525,10 @@ module.exports.register = function (Handlebars, options, params) {
                 mod = options.hash.mod || 0,
                 limit = options.hash.limit || -1,
                 layout = options.hash.layout || 'horizontal',
-                sortKey = options.hash.sortKey || '',
-                sortDesc = typeof options.hash.sortDesc !== 'undefined' ? options.hash.sortDesc : false,
-                sortA = 1,
-                sortB = -1,
                 j,
                 show;
 
             if (context && context.length) {
-
-                // Sort differently if Needed
-                if (sortKey !== '') {
-                    if (sortDesc) {
-                        sortA = -1;
-                        sortB = 1;
-                    }
-                    context = context.sort(function (a, b) {
-                        return a[sortKey] > b[sortKey] ? sortA : (a[sortKey] < b[sortKey] ? sortB : 0);
-                    });
-                }
 
                 j = context.length;
 
@@ -568,8 +554,6 @@ module.exports.register = function (Handlebars, options, params) {
                                     // These fields should NOT be propagated into child scopes:
                                     switch (h) {
                                         case "nav_links":
-                                        case "sortKey":
-                                        case "sortDesc":
                                         break;
                                         default:
                                             context[i][h] = options.hash[h];

--- a/src/layouts/layout-blog-post.hbs
+++ b/src/layouts/layout-blog-post.hbs
@@ -1,8 +1,8 @@
 ---
 layout: layout-sidebar
 limit: <%= stache.config.blog_recent_limit %>
-sortKey: 'uri'
-sortDesc: true
+sortKey: uri
+sortDirection: desc
 ---
 
 {{ include 'partial-blog-header' this isSingle=true }}

--- a/src/layouts/layout-blog.hbs
+++ b/src/layouts/layout-blog.hbs
@@ -1,13 +1,13 @@
 ---
 layout: layout-sidebar
 limit: <%= stache.config.blog_recent_limit %>
-sortKey: 'uri'
-sortDesc: true
+sortKey: uri
+sortDirection: desc
 ---
 
 {{ body }}
 
-{{# eachChildLink sortKey=sortKey sortDesc=sortDesc }}
+{{# eachChildLink }}
   {{# if sticky }}
     <div class="blog-post-summary">
       {{ include 'partial-blog-header' }}
@@ -22,7 +22,7 @@ sortDesc: true
   {{/ if }}
 {{/ eachChildLink }}
 
-{{# eachChildLink sortKey=sortKey sortDesc=sortDesc blogReadMoreLabel=blogReadMoreLabel }}
+{{# eachChildLink blogReadMoreLabel=blogReadMoreLabel }}
   {{# unless sticky }}
     <div class="blog-post-summary">
       {{ include 'partial-blog-header' }}

--- a/src/partials/partial-sidebar.hbs
+++ b/src/partials/partial-sidebar.hbs
@@ -1,5 +1,5 @@
 {{# if nav_links }}
-  {{# eachWithMod nav_links limit=limit sortKey=sortKey sortDesc=sortDesc }}
+  {{# eachWithMod nav_links limit=limit }}
     {{# isActiveNav dest=../../dest }}
 
       {{# withinParentDepth sidebarCurrentDepth=../../../sidebarCurrentDepth sidebarParentDepth=../../../sidebarParentDepth }}

--- a/stache.yml
+++ b/stache.yml
@@ -109,8 +109,8 @@ video_description_top: false
 watchNewer: true
 modules:
   - stache
-sortKey: ""
-sortDesc: false
+sortKey: order
+sortDirection: asc
 
 # =============================================
 # STACHE - ANALYTICS


### PR DESCRIPTION
Sorting is now done completely by **tasks/stache.js**. Each page/layout can still override the default behaviors via FM, however.
