### PR TITLE
Added custom layouts to createAutoNav functionality.

### DIFF
--- a/stache.yml
+++ b/stache.yml
@@ -4,6 +4,7 @@
 base: /
 static: static/
 content: content/
+customContent: custom-content/
 includes: includes/
 data: data/
 blog: blog/

--- a/stache.yml
+++ b/stache.yml
@@ -4,7 +4,6 @@
 base: /
 static: static/
 content: content/
-customContent: custom-content/
 includes: includes/
 data: data/
 blog: blog/
@@ -15,6 +14,8 @@ css: <%= stache.config.src %>css/
 helpers: <%= stache.config.src %>helpers/
 partials: <%= stache.config.src %>partials/
 layouts: <%= stache.config.src %>layouts/
+paths:
+  custom: custom-content/
 error:
   404: <%= stache.config.build %>404/index.html
 

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -51,7 +51,9 @@ module.exports = function (grunt) {
         stache: {
 
             // Stores all YAML configuration properties (extends global Stache YAML).
-            config: {},
+            config: {
+                paths: {}
+            },
 
             // The relative path to the Stache NPM package.
             // (Necessary since we are actually running in the root project folder.)
@@ -86,7 +88,7 @@ module.exports = function (grunt) {
                 },
                 layoutsCustom: {
                     expand: true,
-                    cwd: '<%= stache.config.customContent %>layouts/',
+                    cwd: '<%= stache.config.paths.custom %>layouts/',
                     src: ['**/*.hbs']
                 }
             },
@@ -338,7 +340,7 @@ module.exports = function (grunt) {
             processStacheCastleMultipleNodes = function (page, node, parents) {
                 if (node) {
                     if (node.length > 0) {
-                        node.forEach(function (v, idx) {
+                        node.forEach(function (v) {
                             processStacheCastleSingleNode(page, v, parents, node);
                         });
                     } else {
@@ -535,10 +537,9 @@ module.exports = function (grunt) {
 
             // Create the nav_links array.
             if (sorted) {
-                sorted.forEach(function (el, idx) {
+                sorted.forEach(function (el) {
 
                     var path = root,
-                        rootdir = el.rootdir,
                         subdir = el.subdir,
                         filename = el.filename,
                         separator = grunt.config.get('stache.config.nav_title_separator') || ' ',
@@ -743,7 +744,6 @@ module.exports = function (grunt) {
                 search = [],
                 item,
                 file,
-                html,
                 content,
                 i,
                 j,
@@ -1126,7 +1126,7 @@ module.exports = function (grunt) {
                 parts = parts.slice(-1);
             }
 
-            parts.forEach(function (el, idx) {
+            parts.forEach(function (el) {
                 output += el[0].toUpperCase() + el.slice(1) + separator;
             });
             output = output.slice(0, 0 - separator.length);
@@ -1216,18 +1216,21 @@ module.exports = function (grunt) {
          * This method also catches deprecated hooks from previous versions.
          */
         setupHooks: function () {
-            var hooks,
+            var hook,
+                hooks,
                 message;
 
             hooks = grunt.config.get('stache.hooks');
 
             // Make sure the task list is an array.
             if (hooks) {
-                for (var hook in hooks) {
-                    if (!utils.isArray(hooks[hook])) {
-                        message = 'The hooks in "' + hook + '" should be listed in an array format (for example, `[\'task1\', \'task2\', \'task3\']`).';
-                        slog.warning(message);
-                        hooks[hook] = [hooks[hook]];
+                for (hook in hooks) {
+                    if (hooks.hasOwnProperty(hook)) {
+                        if (!utils.isArray(hooks[hook])) {
+                            message = 'The hooks in "' + hook + '" should be listed in an array format (for example, `[\'task1\', \'task2\', \'task3\']`).';
+                            slog.warning(message);
+                            hooks[hook] = [hooks[hook]];
+                        }
                     }
                 }
                 grunt.config.set('stache.hooks', hooks);
@@ -1263,8 +1266,7 @@ module.exports = function (grunt) {
             // Require all heading tags to have id attribute
             cheerio('h1, h2, h3, h4, h5, h6', $html).each(function () {
                 var el = cheerio(this),
-                    id = el.attr('id'),
-                    after;
+                    id = el.attr('id');
                 if (typeof id === 'undefined' || id === '') {
                     el.attr('id', utils.slugify(el.text()));
                 }
@@ -1332,7 +1334,7 @@ module.exports = function (grunt) {
 
                 utils.sort(links, rules);
 
-                links.forEach(function (link, i) {
+                links.forEach(function (link) {
 
                     if (link.sortKey && link.nav_links) {
                         switch (link.sortKey) {

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -1437,7 +1437,8 @@ module.exports = function (grunt) {
         // Get the default layout name.
         defaultLayoutName = grunt.config.get('assemble.options.layout');
         if (layoutsFrontMatter[defaultLayoutName] === undefined) {
-            throw new Error("You must specify a default layout in `assemble.options.layout`!");
+            slog.warning("A default layout was not found. It is recommended that you specify a default layout in `assemble.options.layout`.");
+            return;
         }
 
         // These fields should be merged from the page-level into the layout-level.


### PR DESCRIPTION
This feature should work with a default install of Stache (where the custom layouts are stored in `/custom-content/layouts/`). If your custom layouts are stored in a different directory, you can specify the name of your custom content directory in your **stache.yml** file, like this:

```
customContent: my-custom-folder/
```

The folder in which the layout files live must still be called "layouts".
