### PR TITLE
Updated selector to match Omnibar

### DIFF
--- a/src/sass/_omnibar.scss
+++ b/src/sass/_omnibar.scss
@@ -7,7 +7,7 @@
 
 // Necessary since we want this menu regardless of being logged in.
 // Also has to be more specific in order to override async omnibar css.
-.bb-omnibar .mobile .bar .menuheader {
+.bb-omnibar.bb-omnibar-signedout .bb-omnibar-mobile-menuheader {
   display: block;
 }
 


### PR DESCRIPTION
The omnibar's default functionality is to hide the mobile nav menu if a user is not logged in.  As Stache sties are not typical "applications," I previously fixed this by making the mobile menu visible regardless of login status.

During a recent Omnibar update, the CSS classes used were changed.  This is to correct that.
