### PR TITLE
Ignore web config

### DIFF
--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -240,11 +240,13 @@ module.exports.register = function (Handlebars, options, params) {
          * @param {string} [activeURI] The path of the active page.
          */
         findBreadcrumb: function (navLinks, activeURI) {
-            var breadcrumbs,
+            var base,
+                breadcrumbs,
                 i,
                 navLink,
                 navLinksLength;
 
+            base = stache.config.base;
             breadcrumbs = [];
             navLinksLength = navLinks.length;
 
@@ -254,7 +256,7 @@ module.exports.register = function (Handlebars, options, params) {
 
                 // Don't include the Home page because it cannot have sub-directories.
                 // (We add the Home page manually, in getBreadcrumbNavLinks.)
-                if (navLink.uri !== "/") {
+                if (navLink.uri !== base) {
 
                     // Is this page's URI a fragment of the active page's URI?
                     if (activeURI.indexOf(navLink.uri) > -1) {

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -244,8 +244,15 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd: '<%= stache.config.static %>',
-                        src: '**/*.*',
+                        src: [
+                            '**/*.*',
+                            '!web.config'
+                        ],
                         dest: '<%= stache.config.build %><%= stache.config.base %>'
+                    },
+                    {
+                        src: '<%= stache.config.static %>web.config',
+                        dest: '<%= stache.config.build %>web.config'
                     },
                     {
                         expand: true,


### PR DESCRIPTION
- Copies the web.config file into the build root folder, effectively ignoring the recently added support for base.  
- Adjusted breadcrumbs to support a custom base.
