### PR TITLE
Fixed column widths at phone breakpoint.

### DIFF
--- a/src/layouts/layout-base.hbs
+++ b/src/layouts/layout-base.hbs
@@ -111,7 +111,7 @@
                   <div class="col-xs-6 col-sm-4">
                     {{{ include stache.config.partial_footer_internal }}}
                   </div>
-                  <div class="col-sm-4">
+                  <div class="col-xs-6 col-sm-4">
                     {{{ include stache.config.partial_footer_social }}}
                   </div>
                 </div>

--- a/src/layouts/layout-base.hbs
+++ b/src/layouts/layout-base.hbs
@@ -108,11 +108,12 @@
                     {{{ include stache.config.partial_footer_logo }}}
                     {{{ include stache.config.partial_footer_navigation }}}
                   </div>
-                  <div class="col-xs-6 col-sm-4">
-                    {{{ include stache.config.partial_footer_internal }}}
-                  </div>
-                  <div class="col-xs-6 col-sm-4">
+                  <div class="col-xs-6 col-sm-4 col-sm-push-4">
                     {{{ include stache.config.partial_footer_social }}}
+                  </div>
+                  <div class="clearfix visible-xs-block"></div>
+                  <div class="col-sm-4 col-sm-pull-4">
+                    {{{ include stache.config.partial_footer_internal }}}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
The footer columns were overlapping each other, preventing some links from being clickable.
