### PR TITLE
Stache Release and Config

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   "dependencies": {
     "assemble": "^0.4.42",
     "assemble-yaml": "^0.2.1",
+    "blackbaud-marked": "git://github.com/blackbaud-community/marked.git",
     "cheerio": "^0.18.0",
     "grunt": "^0.4.5",
     "grunt-asciify": "^0.2.2",
     "grunt-available-tasks": "^0.5.6",
+    "grunt-bump": "^0.8.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.9.0",
@@ -27,7 +29,6 @@
     "grunt-newer": "^1.1.1",
     "helper-moment": "^0.1.0",
     "html-minifier": "^1.0.0",
-    "blackbaud-marked": "git://github.com/blackbaud-community/marked.git",
     "merge": "^1.2.0",
     "uglify-js": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "name": "blackbaud-stache",
   "version": "0.7.31",
   "description": "Blackbaud Stache",
+  "licence": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/blackbaud/stache.git"
@@ -15,20 +16,19 @@
   "dependencies": {
     "assemble": "^0.4.42",
     "assemble-yaml": "^0.2.1",
-    "blackbaud-marked": "git://github.com/blackbaud-community/marked.git",
     "cheerio": "^0.18.0",
     "grunt": "^0.4.5",
     "grunt-asciify": "^0.2.2",
     "grunt-available-tasks": "^0.5.6",
-    "grunt-bump": "^0.8.0",
+    "grunt-bump": "0.7.0",
     "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-newer": "^1.1.1",
     "helper-moment": "^0.1.0",
     "html-minifier": "^1.0.0",
+    "blackbaud-marked": "git://github.com/blackbaud-community/marked.git",
     "merge": "^1.2.0",
     "uglify-js": "^2.5.0"
   },

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -1186,7 +1186,8 @@ module.exports = function (grunt) {
 
                         // Setting a stache.config property:
                         if (file.indexOf(':') > -1) {
-                            localConfig = merge.recursive(true, localConfig, utils.parseOptionString(configFileString));
+                            slog('Setting config variable `' + file + '`.');
+                            localConfig = merge.recursive(true, localConfig, utils.parseOptionString(file));
                         }
 
                         // Merge a YAML file:
@@ -1254,6 +1255,7 @@ module.exports = function (grunt) {
             arr = str.split(':');
             option = {};
             option[arr[0].trim()] = arr[1].trim();
+            slog.success("Option created..." + JSON.stringify(option));
             return option;
         },
 
@@ -1637,7 +1639,6 @@ module.exports = function (grunt) {
         grunt.registerTask('release', 'Bump the version number in package.json; commit to origin.', tasks.stacheRelease);
         grunt.registerTask('serve', 'Serve the documentation', tasks.stacheServe);
         grunt.registerTask('version', 'Display the currently installed version of Stache', tasks.stacheVersion);
-        //grunt.registerTask('config', 'Set a config property.', tasks.stacheConfig);
     }());
 
 

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -832,10 +832,6 @@ module.exports = function (grunt) {
 
             utils.setupHooks();
 
-            console.log("stacheBuild");
-            console.log(context);
-            console.log("ENV:", process.env);
-
             switch (context) {
             default:
                 tasks = [

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -939,6 +939,12 @@ module.exports = function (grunt) {
             grunt.task.run(tasks);
         },
 
+        // stacheConfig: function (name, val) {
+        //     grunt.config.set(name, val);
+        //     console.log(name + " set to: " + grunt.config(name));
+        //     console.log(grunt.config('stache.config'));
+        // },
+
         /**
          * Bash command: stache version
          * Prints the current version of Stache in the console.
@@ -1177,14 +1183,29 @@ module.exports = function (grunt) {
                 if (configFileString.indexOf(',') > -1) {
                     configFileString.split(',').forEach(function (file) {
                         file = file.trim();
-                        if (grunt.file.exists(file)) {
+
+                        // Setting a stache.config property:
+                        if (file.indexOf(':') > -1) {
+                            localConfig = merge.recursive(true, localConfig, utils.parseOptionString(configFileString));
+                        }
+
+                        // Merge a YAML file:
+                        else if (grunt.file.exists(file)) {
                             slog('Importing config file ' + file);
                             localConfig = merge.recursive(true, localConfig, grunt.file.readYAML(file));
-                        } else {
+                        }
+
+                        // Command not recognized:
+                        else {
                             slog.warning('Error importing config file ' + file);
                         }
                     });
 
+                }
+
+                // Setting a stache.config property:
+                else if (configFileString.indexOf(':') > -1) {
+                    localConfig = merge.recursive(true, localConfig, utils.parseOptionString(configFileString));
                 }
 
                 // Only one file specified.
@@ -1222,6 +1243,18 @@ module.exports = function (grunt) {
          */
         isArray: function (arr) {
             return (arr.pop && arr.push);
+        },
+
+        /**
+         * Takes a given option string, `foo:bar`, and converts it into an object.
+         */
+        parseOptionString: function (str) {
+            var arr,
+                option;
+            arr = str.split(':');
+            option = {};
+            option[arr[0].trim()] = arr[1].trim();
+            return option;
         },
 
         /**
@@ -1604,6 +1637,7 @@ module.exports = function (grunt) {
         grunt.registerTask('release', 'Bump the version number in package.json; commit to origin.', tasks.stacheRelease);
         grunt.registerTask('serve', 'Serve the documentation', tasks.stacheServe);
         grunt.registerTask('version', 'Display the currently installed version of Stache', tasks.stacheVersion);
+        //grunt.registerTask('config', 'Set a config property.', tasks.stacheConfig);
     }());
 
 

--- a/tasks/stache.js
+++ b/tasks/stache.js
@@ -176,12 +176,31 @@ module.exports = function (grunt) {
                         'build',
                         'help',
                         'new',
-                        'prepare',
-                        'publish',
+                        'release',
                         'serve',
                         'version'
                     ]
                 }
+            }
+        },
+
+        bump: {
+            options: {
+                files: ['package.json'],
+                updateConfigs: [],
+                commit: true,
+                commitMessage: 'Release v%VERSION%',
+                commitFiles: ['package.json'],
+                createTag: false,
+                tagName: 'v%VERSION%',
+                tagMessage: 'Version %VERSION%',
+                push: true,
+                pushTo: 'origin',
+                gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+                globalReplace: false,
+                prereleaseName: false,
+                metadata: '',
+                regExp: false
             }
         },
 
@@ -813,6 +832,10 @@ module.exports = function (grunt) {
 
             utils.setupHooks();
 
+            console.log("stacheBuild");
+            console.log(context);
+            console.log("ENV:", process.env);
+
             switch (context) {
             default:
                 tasks = [
@@ -851,6 +874,12 @@ module.exports = function (grunt) {
          * tasks help screen. (It's defined in the blackbaud-stache-cli package.)
          */
         stacheNew: function () {},
+
+        stacheRelease: function (type) {
+            type = type || 'patch';
+            slog.muted("Running `stache release " + type + "`...");
+            grunt.task.run('bump:' + type);
+        },
 
         /**
          * Bash command: stache serve
@@ -1176,7 +1205,7 @@ module.exports = function (grunt) {
 
             // Expand default local Stache YAML file into workable object, if it exists.
             else if (grunt.file.exists(stache.pathConfig)) {
-                slog('Defaulting to config file ' + stache.pathConfig);
+                slog.muted('Defaulting to config file ' + stache.pathConfig);
                 localConfig = grunt.file.readYAML(stache.pathConfig);
             }
 
@@ -1510,11 +1539,12 @@ module.exports = function (grunt) {
             'assemble',
             'grunt-asciify',
             'grunt-available-tasks',
+            'grunt-bump',
             'grunt-contrib-clean',
             'grunt-contrib-connect',
             'grunt-contrib-copy',
             'grunt-contrib-watch',
-            'grunt-newer',
+            'grunt-newer'
         ];
 
         // Merge options and defaults for the entire project.
@@ -1575,6 +1605,7 @@ module.exports = function (grunt) {
         grunt.registerTask('build', 'Build the documentation', tasks.stacheBuild);
         grunt.registerTask('help', 'Display available Stache commands', tasks.stacheHelp);
         grunt.registerTask('new', 'Create a new site using the Stache boilerplate', tasks.stacheNew);
+        grunt.registerTask('release', 'Bump the version number in package.json; commit to origin.', tasks.stacheRelease);
         grunt.registerTask('serve', 'Serve the documentation', tasks.stacheServe);
         grunt.registerTask('version', 'Display the currently installed version of Stache', tasks.stacheVersion);
     }());


### PR DESCRIPTION
**New command `stache release`**
- Uses `grunt bump` to automatically adjust **package.json** version number and commits to remote
- Also accepts same parameters as `grunt bump`, such as `stache release minor --dry-run`

**New method to pass configuration variables**
- You may now add specific config variables to the `stache.config` object, via command line
- Type `stache build --config=build:deploy/` 
- `stache.config.build` will then be set to "deploy/"
